### PR TITLE
Fix source file tracking

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -56,12 +56,12 @@ def bazel_build(image, target):
   watch_labels(build_deps)
 
   source_deps = str(local(BAZEL_SOURCES_CMD % target)).splitlines()
-  source_deps_files =bazel_labels_to_files(source_deps)
+  source_deps_files = bazel_labels_to_files(source_deps)
 
   custom_build(
     image,
     BAZEL_RUN_CMD % target,
-    source_deps,
+    source_deps_files,
     tag="image",
   )
 


### PR DESCRIPTION
The result of calling bazel_labels_to_files was not being used.