### PR TITLE
bazel: update the bazel example to retag images instead of using custom_build(tag)

### DIFF
--- a/deploy/snack.yaml
+++ b/deploy/snack.yaml
@@ -1,25 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: varowner-snack
+  name: snack
   labels:
     app: snack
-    owner: varowner
 spec:
   selector:
     matchLabels:
       app: snack
-      owner: varowner
   template:
     metadata:
       labels:
         app: snack
         tier: web
-        owner: varowner
     spec:
       containers:
       - name: snack
-        image: bazel/snack
+        image: snack-image
         ports:
         - containerPort: 8083
         resources:

--- a/deploy/vigoda.yaml
+++ b/deploy/vigoda.yaml
@@ -1,25 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: varowner-vigoda
+  name: vigoda
   labels:
     app: vigoda
-    owner: varowner
 spec:
   selector:
     matchLabels:
       app: vigoda
-      owner: varowner
   template:
     metadata:
       labels:
         app: vigoda
         tier: web
-        owner: varowner
     spec:
       containers:
       - name: vigoda
-        image: bazel/vigoda
+        image: vigoda-image
         env:
         - name: TEMPLATE_DIR
           value: "/go/src/github.com/windmilleng/servantes/vigoda/web/templates"


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/no-tags:

aabd615abbee104f8f06d1f3998788778c984eda (2020-10-30 12:41:25 -0400)
bazel: update the bazel example to retag images instead of using custom_build(tag)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics